### PR TITLE
Permission Request on App Focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.2.1] - 2023.03.08
+
+### Added
+- Permission request in OnApplicationFocus method of WebViewBase.
+
 ## [0.2.0] - 2023.02.08
 
 ### Added

--- a/Runtime/Native/AndroidWebView.cs
+++ b/Runtime/Native/AndroidWebView.cs
@@ -13,12 +13,17 @@ namespace ReadyPlayerMe.WebView
         private AndroidJavaObject webView;
         private AndroidJavaObject rectangle;
 
-        public override void Init(WebViewOptions options)
+        public override void AskPermission()
         {
             if (!Permission.HasUserAuthorizedPermission(Permission.Camera))
             {
                 Permission.RequestUserPermission(Permission.Camera);
             }
+        }
+
+        public override void Init(WebViewOptions options)
+        {
+            AskPermission();
 
             webView = new AndroidJavaObject(WebViewAndroidPluginName);
             webView.Call("Init", name, options.Transparent, options.Zoom, (int)options.ColorMode, options.UserAgent);

--- a/Runtime/Native/IOSWebView.cs
+++ b/Runtime/Native/IOSWebView.cs
@@ -12,12 +12,17 @@ namespace ReadyPlayerMe.WebView
     {
         private IntPtr webView;
 
-        public override void Init(WebViewOptions options)
+        public override void AskPermission()
         {
             if (!Application.HasUserAuthorization(UserAuthorization.WebCam))
             {
                 Application.RequestUserAuthorization(UserAuthorization.WebCam);
             }
+        }
+
+        public override void Init(WebViewOptions options)
+        {
+            AskPermission();
 
             webView = _CWebViewPlugin_Init(name, options.Transparent, options.Zoom, options.UserAgent, options.EnableWKWebView,
                 (int) options.ContentMode);

--- a/Runtime/Native/WebViewBase.cs
+++ b/Runtime/Native/WebViewBase.cs
@@ -22,6 +22,16 @@ namespace ReadyPlayerMe.WebView
         protected MessagePanel messageCanvas;
         protected int windowVisibleDisplayFrameHeight;
 
+        private void OnApplicationFocus(bool hasFocus)
+        {
+            if (hasFocus)
+            {
+                AskPermission();
+            }
+        }
+
+        public abstract void AskPermission();
+
         public abstract void Init(WebViewOptions options);
 
         public abstract void SetMargins(int left, int top, int right, int bottom);


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Monday and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [4108899206](https://ready-player-me.monday.com/boards/2563815861/pulses/4108899206)

## Description

-   If a user loses app focus during the permission popup, it will be closed and upon return to the app, user will continue without permission which will result in the take a photo button not working.

<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

## Changes

#### Added

- Permission request in OnApplicationFocus method of WebViewBase.

<!-- Testability -->

## How to Test

- Build WebView sample, open the WebView
- Obverse the permission popup
- Close the app. Do not shut it down but switch to mobile home page or other app.
- Return to the unity app and observe permission window missing.
- With the fix permission window will be appearing again.

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [x] Changelog is updated.
-   [ ] QA Testing is updated.

## QA Testing

-   Mention any useful test cases for this feature and add to QA Testing documentation.

## Details

-   If more details are necessary to support the description with images and videos add them here.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->



