### PR TITLE
safer null check for MessagePanel

### DIFF
--- a/Runtime/WebViewPanel.cs
+++ b/Runtime/WebViewPanel.cs
@@ -48,8 +48,12 @@ namespace ReadyPlayerMe.WebView
 #else
             InitializeAndShowWebView(loginToken);
 #endif
-            messagePanel.SetMessage(messageType);
-            messagePanel.SetVisible(true);
+            if (messagePanel)
+            {
+                messagePanel.SetMessage(messageType);
+                messagePanel.SetVisible(true);
+            }
+
             SetScreenPadding();
         }
 
@@ -92,8 +96,12 @@ namespace ReadyPlayerMe.WebView
         /// </summary>
         public void SetVisible(bool visible)
         {
-            messagePanel.SetVisible(visible);
-            if (webViewObject != null)
+            if (messagePanel)
+            {
+                messagePanel.SetVisible(visible);
+            }
+
+            if (webViewObject)
             {
                 webViewObject.IsVisible = visible;
             }
@@ -102,7 +110,7 @@ namespace ReadyPlayerMe.WebView
         private void OnDrawGizmos()
         {
             var rectTransform = transform as RectTransform;
-            if (rectTransform != null)
+            if (rectTransform)
             {
                 Gizmos.matrix = rectTransform.localToWorldMatrix;
                 Gizmos.color = Color.green;
@@ -123,7 +131,10 @@ namespace ReadyPlayerMe.WebView
                 webViewObject.SetMargins(screenPadding.left, screenPadding.top, screenPadding.right, screenPadding.bottom);
             }
 
-            messagePanel.SetMargins(screenPadding.left, screenPadding.top, screenPadding.right, screenPadding.bottom);
+            if (messagePanel)
+            {
+                messagePanel.SetMargins(screenPadding.left, screenPadding.top, screenPadding.right, screenPadding.bottom);
+            }
         }
 
         // Receives message from RPM website, which contains avatar URL.


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Jira and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## Description

Sometimes we want to use webViewPanel without MessagePanel. But there if no check and it would throw error

<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

## Changes

#### Added

- Check `messagePanel` with `if`

#### Updated

- Use `if` check for some other unity object, because null propagation is not fully cover unity nullability for destroy object

<!-- Testability -->

## How to Test

- Use webview without setting a message panel 

<!-- Update your progress with the task here -->

## Checklist

-   [ x ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->



